### PR TITLE
Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This repository formerly hosted Sage Bionetworks' R Archive Network - it is now deprecated in favor of http://ran.synapse.org/
+
 ![Sage Bionetworks logo](sage-bionetworks.png)
 
 # Sage Bionetworks R Archive Network


### PR DESCRIPTION
This repository formerly hosted Sage R packages via GitHub pages but is now deprecated in favor of the s3 based http://ran.synapse.org.

The repo should be archived.